### PR TITLE
Update rustup to 1.21.1

### DIFF
--- a/rustup.install.nuspec
+++ b/rustup.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rustup.install</id>
-    <version>1.19.0</version>
+    <version>1.21.1</version>
     <packageSourceUrl>https://github.com/camilohe/rustup.install</packageSourceUrl>
     <owners>camilohe</owners>
 

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -13,9 +13,9 @@ $packageArgs = @{
 
     softwareName   = 'rustup*' 
 
-    checksum       = '22F51975DCC460198FB576AFEC5D38D47E4F1B8E28185AE2312D57CF9D35DA1C'
+    checksum       = 'B98D6677B55DB9C7DA8582A6279FF841DD49CEE93CD9BB67F9773995F1083F41'
     checksumType   = 'sha256' 
-    checksum64     = 'E325B428A0FF9132B59EC586E85B1DB4EAA66ACC13B3DAF8090520D2E7694388'
+    checksum64     = '9F9E33FA4759075EC60E4DA13798D1D66A4C2F43C5500E08714399313409DCF5'
     checksumType64 = 'sha256' 
 
     silentArgs     = '-v -y' # it seems we need '-v -y' starting with 1.9.0 to get rustup copied to the .cargo\bin folder.


### PR DESCRIPTION
From discussion on the chocolatey site:

> The hashes are not up to date:
> 
> Download of rustup-init.exe (8.24 MB) completed.
> Error - hashes do not match. Actual value was '9F9E33FA4759075EC60E4DA13798D1D66A4C2F43C5500E08714399313409DCF5'.
> 
> The current x64 sha256 hash is: 9f9e33fa4759075ec60e4da13798d1d66a4c2f43c5500e08714399313409dcf5

https://chocolatey.org/packages/rustup.install#comment-4734720205